### PR TITLE
 MGP-0004 | Update MoolaOracle asset sources and fallback oracle

### DIFF
--- a/MGPs/mgp-0004.md
+++ b/MGPs/mgp-0004.md
@@ -4,9 +4,9 @@ mgp: 4
 title: Update MoolaOracle to use the new CeloProxyPriceProvider as sources for cUSD, cEUR and cREAL, and use UbeswapPriceFeed as fallback oracle
 date-created: 2022-04-19
 author: Xiaoyun Yang (@x-moola)
-status: TESTNET
+status: MINNET
 governance-proposal-id: 4
-date-executed:
+date-executed: 2022-04-21
 ---
 ```
 
@@ -54,4 +54,4 @@ Verify the function names and params of all TXs.
 
 # Risks
 
-Low. The new [CeloProxyPriceProvider](https://explorer.celo.org/address/0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4/read-contract) and [UbeswapPriceFeed](https://explorer.celo.org/address/0xb13F9Fb45B2E4446EF0047CBB2b9Dee269162309/transactions) source code is verified and has been tested on Alfajores. The main price source is still the sorted oracles which is the same as before, just added the logic to trigger fallback oracle instead of reverting when the price is 0.
+Low. The new [CeloProxyPriceProvider](https://explorer.celo.org/address/0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4/read-contract) and [UbeswapPriceFeed](https://explorer.celo.org/address/0xb13F9Fb45B2E4446EF0047CBB2b9Dee269162309/transactions) source code is verified and has been tested on Alfajores. The main price source is still the sorted oracles which is the same as before, just added the logic to trigger fallback oracle instead of reverting when the price is 0. The revert transactions are also ready to go if anything goes wrong, they will revert the oracle setup to its original state.

--- a/MGPs/mgp-0004.md
+++ b/MGPs/mgp-0004.md
@@ -1,0 +1,57 @@
+```
+---
+mgp: 4
+title: Update MoolaOracle to use the new CeloProxyPriceProvider as sources for cUSD, cEUR and cREAL, and use UbeswapPriceFeed as fallback oracle
+date-created: 2022-04-19
+author: Xiaoyun Yang (@x-moola)
+status: TESTNET
+governance-proposal-id: 4
+date-executed:
+---
+```
+
+# Overview
+
+Update MoolaOracle to use the new CeloProxyPriceProvider as sources for cUSD, cEUR and cREAL, and use UbeswapPriceFeed as fallback oracle.
+
+# Proposed changes
+
+1. TX 125: Update fallback oracle to [UbeswapPriceFeed](https://explorer.celo.org/address/0xb13F9Fb45B2E4446EF0047CBB2b9Dee269162309/transactions)
+
+```
+setFallbackOracle
+  _fallbackOracle = 0xb13F9Fb45B2E4446EF0047CBB2b9Dee269162309
+```
+
+2. TX 126: Update asset sources of cUSD, cEUR, and cREAL to the new [CeloProxyPriceProvider](https://explorer.celo.org/address/0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4/read-contract)
+
+```
+setAssetSources:
+  _assets = 0x765DE816845861e75A25fCA122bb6898B8B1282a,0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73,0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787
+  _sources = 0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4,0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4,0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4
+```
+
+## Revert transactions
+
+1. TX 127: The revert transaction for TX 126, set sources of cUSD, cEUR and cREAL back to the [previous CeloProxyPriceProvider](https://explorer.celo.org/address/0x568547688121AA69bDEB8aEB662C321c5D7B98D0/read-contract)
+
+```
+setAssetSources
+  _assets = 0x765DE816845861e75A25fCA122bb6898B8B1282a,0xD8763CBa276a3738E6DE85b4b3bF5FDed6D6cA73,0xe8537a3d056DA446677B9E9d6c5dB704EaAb4787
+  _sources = 0x568547688121AA69bDEB8aEB662C321c5D7B98D0,0x568547688121AA69bDEB8aEB662C321c5D7B98D0,0x568547688121AA69bDEB8aEB662C321c5D7B98D0
+```
+
+2. TX 128: The revert transaction for TX 125, set fallback oracle back to `0x0000000000000000000000000000000000000000`
+
+```
+setFallbackOracle
+  _fallbackOracle = 0x0000000000000000000000000000000000000000
+```
+
+# Verification
+
+Verify the function names and params of all TXs.
+
+# Risks
+
+Low. The new [CeloProxyPriceProvider](https://explorer.celo.org/address/0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4/read-contract) and [UbeswapPriceFeed](https://explorer.celo.org/address/0xb13F9Fb45B2E4446EF0047CBB2b9Dee269162309/transactions) source code is verified and has been tested on Alfajores. The main price source is still the sorted oracles which is the same as before, just added the logic to trigger fallback oracle instead of reverting when the price is 0.


### PR DESCRIPTION
Update MoolaOracle to use the new [CeloProxyPriceProvider](https://explorer.celo.org/address/0x9F9037cE8deB6e8EF3045aD5C1a31D93895446C4/read-contract) as sources for cUSD, cEUR and cREAL, and use [UbeswapPriceFeed](https://explorer.celo.org/address/0xb13F9Fb45B2E4446EF0047CBB2b9Dee269162309/transactions) as fallback oracle.